### PR TITLE
fix v2ray-server tcpsettings (#5820)

### DIFF
--- a/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/api/genv2rayconfig.lua
+++ b/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/api/genv2rayconfig.lua
@@ -92,6 +92,17 @@ local v2ray = {
                     }
                 }
             } or nil,
+            tcpSettings = (server.transport == "tcp") and {
+                header = {
+                    type = server.tcp_guise,
+                    request = {
+                        path = server.tcp_guise_http_path,
+                        headers = {
+                            Host = server.tcp_guise_http_host
+                        }
+                    }
+			    }
+            } or nil,
             kcpSettings = (server.transport == "mkcp") and {
                 mtu = tonumber(server.mkcp_mtu),
                 tti = tonumber(server.mkcp_tti),


### PR DESCRIPTION
修复传输方式为tcp时，http伪装不生效的问题。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
