### PR TITLE
Revert "ramips: mt7621 default overclock to 1000Mhz" (#6190)

### DIFF
--- a/target/linux/ramips/patches-5.4/102-mt7621-fix-cpu-clk-add-clkdev.patch
+++ b/target/linux/ramips/patches-5.4/102-mt7621-fix-cpu-clk-add-clkdev.patch
@@ -65,7 +65,7 @@
  #define MT7621_GPIO_MODE_UART1		1
  #define MT7621_GPIO_MODE_I2C		2
  #define MT7621_GPIO_MODE_UART3_MASK	0x3
-@@ -111,49 +111,98 @@ static struct rt2880_pmx_group mt7621_pi
+@@ -111,49 +111,89 @@ static struct rt2880_pmx_group mt7621_pi
  	{ 0 }
  };
  
@@ -154,15 +154,6 @@
 -			cpu_clk = 20 * fbdiv * 1000 * 1000;
 -		}
 +		pll = rt_memc_r32(MEMC_REG_CPU_PLL);
-+		if ((pll & 0x7f0) == 0x2b0) {
-+			volatile u32 i;
-+
-+			pr_info("CPU Clock: 880MHz, start overclocking\n");
-+			pll &= ~0x7ff;
-+			pll |= 0x312;
-+			rt_memc_w32(pll, MEMC_REG_CPU_PLL);
-+			for (i = 0; i < 1000; i++);
-+		}
 +		fbdiv = (pll >> CPU_PLL_FBDIV_SHIFT) & CPU_PLL_FBDIV_MASK;
 +		prediv = (pll >> CPU_PLL_PREDIV_SHIFT) & CPU_PLL_PREDIV_MASK;
 +		cpu_clk = ((fbdiv + 1) * xtal_clk) >> prediv_tbl[prediv];


### PR DESCRIPTION
This reverts commit 5be81314bb08934fbe03c2e26191b80f021b0d2b. Many users
reported that this commit broken their router. The mips platform does not
support changing the operating frequency of cpu while system is running.
Obviously it is more appropriate to use breed to overclock.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
